### PR TITLE
Fix $timestamp handling in Marshal and Unmarshal

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -43,6 +43,8 @@ func Marshal(in interface{}) (interface{}, error) {
 			return marshalObjectId(v), nil
 		case time.Time:
 			return marshalTime(v), nil
+		case bson.MongoTimestamp:
+			return marshalTimestamp(v), nil
 		case bson.RegEx:
 			return marshalRegex(v), nil
 		case string, int, int64, bool, float64, uint8, uint32:

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -28,6 +28,11 @@ func TestMarshal(t *testing.T) {
 			nil,
 		},
 		{
+			bson.MongoTimestamp(5982128723015499777),
+			[]byte("{\"$timestamp\":{\"i\":1,\"t\":1392822881}}"),
+			nil,
+		},
+		{
 			bson.Binary{Kind: 0x80, Data: []byte("52dc18556c528d7736000003")},
 			[]byte("{\"$binary\":\"NTJkYzE4NTU2YzUyOGQ3NzM2MDAwMDAz\",\"$type\":\"80\"}"),
 			nil,

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -157,8 +157,17 @@ func (m M) timestamp() (timestamp bson.MongoTimestamp, ok bool) {
 			if !isok {
 				return
 			}
-			tt, isok := t.(int)
-			if !isok {
+			var tt int
+			switch number := t.(type) {
+			case int:
+				tt = number
+			case int64:
+				tt = int(number)
+			case int32:
+				tt = int(number)
+			case float64:
+				tt = int(number)
+			default:
 				return
 			}
 
@@ -166,8 +175,17 @@ func (m M) timestamp() (timestamp bson.MongoTimestamp, ok bool) {
 			if !isok {
 				return
 			}
-			ii, isok := i.(int)
-			if !isok {
+			var ii int
+			switch number := i.(type) {
+			case int:
+				ii = number
+			case int64:
+				ii = int(number)
+			case int32:
+				ii = int(number)
+			case float64:
+				ii = int(number)
+			default:
 				return
 			}
 

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -189,6 +189,26 @@ func TestTimestamp(t *testing.T) {
 			bson.MongoTimestamp(5982128723015499777),
 			false,
 		},
+		{
+			map[string]interface{}{"$timestamp": map[string]interface{}{"t": int(1392822881), "i": int(1)}},
+			bson.MongoTimestamp(5982128723015499777),
+			true,
+		},
+		{
+			map[string]interface{}{"$timestamp": map[string]interface{}{"t": int64(1392822881), "i": int64(1)}},
+			bson.MongoTimestamp(5982128723015499777),
+			true,
+		},
+		{
+			map[string]interface{}{"$timestamp": map[string]interface{}{"t": int32(1392822881), "i": int32(1)}},
+			bson.MongoTimestamp(5982128723015499777),
+			true,
+		},
+		{
+			map[string]interface{}{"$timestamp": map[string]interface{}{"t": float64(1392822881), "i": float64(1)}},
+			bson.MongoTimestamp(5982128723015499777),
+			true,
+		},
 	}
 
 	for _, d := range data {
@@ -277,6 +297,10 @@ func TestBsonify(t *testing.T) {
 		{
 			[]byte("{\"name\":\"jp_with_date\",\"created_at\":{\"$date\":1392895436000}}"),
 			bson.M{"name": "jp_with_date", "created_at": sample_time3},
+		},
+		{
+			[]byte("{\"name\":\"jp_with_timestamp\",\"created_at\":{\"$timestamp\":{\"i\":1,\"t\":1392822881}}}"),
+			bson.M{"name": "jp_with_timestamp", "created_at": bson.MongoTimestamp(5982128723015499777)},
 		},
 		{
 			[]byte("{\"vancouver\":{\"$lt\":5}}"),


### PR DESCRIPTION
For marshalling, the timestamp functionality was implemented, however the `bson.MongoTimestamp` object wasn't ever being detected on the input when calling `Marshal()`. This fixes that.

For unmarshalling, this allows for handling `"$timestamp"` inputs with int, int64, int32, or float64 numerics on the `"t"` and `"i"` values inside.  This mainly stems from wanting to handle input from Go's `json.Unmarshal`, which, by default, parses all numbers as floats64s. This meant that `mejson.Unmarshal()` by default would ignore `"$timestamp"` inputs coming from json.Unmarshal. This change allows for those other numeric types to be used, and also aligns with how `"$date"` was already being handled by `Unmarshal` (although, float32 is not being included, since it wouldn't reliably pass the test cases due to precision issues).

Let me know if you think float32 should be included in the `mejson.Unmarshal` handling, or if you have any other comments or suggestions. Thanks!
